### PR TITLE
fix CursorNotFound exception

### DIFF
--- a/tools/sync.py
+++ b/tools/sync.py
@@ -622,8 +622,9 @@ def do_utxo(args):
         logging.info("utxo: Reset all outputs to unspend...")
         db_chain.output.update({"spent":{"$eq":True}},{"$unset":{"spent":1,"spent_in":1}}, multi = True)
 
-    inputs = db_chain.input.find()
+    inputs = db_chain.input.find(no_cursor_timeout=False)
     process_utxo(db_chain, inputs)
+    inputs.close()
 
 def do_help(args):
     print(


### PR DESCRIPTION
mvs_sync_1  | Traceback (most recent call last):
mvs_sync_1  |   File "./tools/sync.py", line 658, in <module>
mvs_sync_1  |     main(sys.argv)
mvs_sync_1  |   File "./tools/sync.py", line 645, in main
mvs_sync_1  |     cmd_action[action](argv[2:])
mvs_sync_1  |   File "./tools/sync.py", line 626, in do_utxo
mvs_sync_1  |     process_utxo(db_chain, inputs)
mvs_sync_1  |   File "./tools/sync.py", line 591, in process_utxo
mvs_sync_1  |     for input in inputs:
mvs_sync_1  |   File "/usr/local/lib/python2.7/site-packages/pymongo/cursor.py", line 1176, in next
mvs_sync_1  |     if len(self.__data) or self._refresh():
mvs_sync_1  |   File "/usr/local/lib/python2.7/site-packages/pymongo/cursor.py", line 1110, in _refresh
mvs_sync_1  |     self.__send_message(g)
mvs_sync_1  |   File "/usr/local/lib/python2.7/site-packages/pymongo/cursor.py", line 970, in __send_message
mvs_sync_1  |     codec_options=self.__codec_options)
mvs_sync_1  |   File "/usr/local/lib/python2.7/site-packages/pymongo/cursor.py", line 1057, in _unpack_response
mvs_sync_1  |     return response.unpack_response(cursor_id, codec_options)
mvs_sync_1  |   File "/usr/local/lib/python2.7/site-packages/pymongo/message.py", line 944, in unpack_response
mvs_sync_1  |     self.raw_response(cursor_id)
mvs_sync_1  |   File "/usr/local/lib/python2.7/site-packages/pymongo/message.py", line 910, in raw_response
mvs_sync_1  |     raise CursorNotFound(msg, 43, errobj)
mvs_sync_1  | pymongo.errors.CursorNotFound: Cursor not found, cursor id: 57928195222